### PR TITLE
Fix blank render for float64 inputs (adjust skip condition for low alpha pixels) 

### DIFF
--- a/src/render.cu
+++ b/src/render.cu
@@ -142,7 +142,8 @@ __global__ void render_tiles_kernel(
                     }
                     alpha = _opacity[i] * norm_prob;
                 }
-                if (alpha < 0.00392156862 || !use_fast_exp) {
+                // Skip pixel if alpha is less than 1/255 and we are in 'inaccurate' mode
+                if (alpha < 0.00392156862 && use_fast_exp) {
                     num_splats++;
                     continue;
                 }

--- a/src/render_backward.cu
+++ b/src/render_backward.cu
@@ -166,7 +166,7 @@ __global__ void render_tiles_backward_kernel(
                 // compute alpha, prevent divide by zero
                 T alpha = min(0.9999, _opacity[i] * norm_prob);
 
-                if (alpha > 0.00392156862 || !use_fast_exp) {
+                if (alpha >= 0.00392156862 || !use_fast_exp) {
                     // if this is the first iteration and background blending was used, update
                     // color_accum with the background contribution
                     if (!background_initialized) {


### PR DESCRIPTION
Fixes https://github.com/joeyan/gaussian_splatting/issues/21
